### PR TITLE
Added entry for geospatial publisher

### DIFF
--- a/connectors/geospatial-publisher.md
+++ b/connectors/geospatial-publisher.md
@@ -1,0 +1,15 @@
+---
+layout: external-link
+title: Socrata Geospatial Publisher
+type: connector
+
+icon: fa-compass
+
+description: This FME template workflow enables writing geospatial data read into FME (using an FME Reader) to an existing Socrata Geospatial Dataset (a.k.a. Mondara Dataset). Use cases include automating publishing geospatial data (including polygons, lines, and points) to Socrata from a Shapefile or geospatial database, as well as optionally transforming, modifying, or adding attributes prior to publishing using FME transformers. <a href="#" target="_blank">View workflow preview</a>
+
+platform: fme
+
+download_url: https://github.com/socrata/connectors/raw/geospatial-publisher/Geospatial%20Publisher/socrata_geospatial_publisher.fmwt
+docs_url: https://github.com/socrata/fme-connectors/tree/master/Geospatial%20Publisher
+bugs_url: https://github.com/socrata/fme-connectors/issues?labels=geospatial-publisher&state=open
+---


### PR DESCRIPTION
Not sure if we want to create a new sub folder for the template workflows such as this one that are more generic. We could call them 'Helper' templates perhaps.
